### PR TITLE
fixes #1 <10.12 compatibility

### DIFF
--- a/GNU-Emacs-OS-X-no-title-bar.patch
+++ b/GNU-Emacs-OS-X-no-title-bar.patch
@@ -14,11 +14,14 @@ diff --git a/src/nsterm.m b/src/nsterm.m
 index 1b44a73..d013101 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -6775,11 +6775,13 @@ - (BOOL)isOpaque
+@@ -6775,11 +6775,16 @@ - (BOOL)isOpaque
    maximizing_resize = NO;
  #endif
 
 -  win = [[EmacsWindow alloc]
++ #if MAC_OS_X_VERSION_MAX_ALLOWED < 101200
++ #define NSWindowStyleMaskBorderless NSBorderlessWindowMask
++ #endif
 +  win = [[EmacsFSWindow alloc]
              initWithContentRect: r
                        styleMask: (NSResizableWindowMask |


### PR DESCRIPTION
As noticed in #1, older sdks rely on NSBorderlessWindowMask rather than NSWindowStyleMaskBorderless. hence we need to bind them for older build environments.

Built and tested for pre 10.12 inside of nix sandbox: https://github.com/peel/GNU-Emacs-OS-X-no-title-bar/blob/test/shell.nix